### PR TITLE
Update paired-fastq-to-unmapped-bam.wdl

### DIFF
--- a/paired-fastq-to-unmapped-bam.wdl
+++ b/paired-fastq-to-unmapped-bam.wdl
@@ -46,7 +46,7 @@ workflow ConvertPairedFastQsToUnmappedBamWf {
     String platform_name 
     String sequencing_center 
 
-    Boolean make_fofn = false
+    Boolean make_fofn = true
 
     String gatk_docker = "broadinstitute/gatk:latest"
     String gatk_path = "/gatk/gatk"


### PR DESCRIPTION
To create unmapped_bam_list file in addition to the unmapped.bam file
Need to set make_fofn to true in the workflow configuration so the the CreateFoFN task runs and the unmapped_bam_list output gets created.